### PR TITLE
Add Git LFS support and example .parquet file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 * text=auto eol=lf
 *.ipynb filter=nbstripout
 *.ipynb diff=ipynb
+tests/testdata/**/*.parquet filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@
 *.feather
 *.gz
 *.orig
-*.parquet
 *.sas7bdat
 *.xls
 *.xlsx

--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
 # ssb-gis-utils
 
 ## Developer information
+
+### Git LFS
+The data in the testdata directory is stored with [Git LFS](https://git-lfs.com/).
+Make sure `git-lfs` is installed and that you have run the command `git lfs install`
+at least once. You only need to run this once per user account.
+
+### Dependencies
+[Poetry](https://python-poetry.org/) is used for dependency management. Install
+poetry and run the command below from the root directory to install the dependencies.  
+```shell
+poetry install --no-root
+```
+
+### Tests
+Use the following command from the root directory to run the tests: 
 ```shell
 poetry run python -m pytest  # from root directory
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "ssb-gis-utils"
 version = "0.1.0"
 description = "GIS utility functions used at Statistics Norway."
-authors = ["Morten Letnes <ort@ssb.no>"]
+authors = ["Statistics Norway <ort@ssb.no>"]
 license = "MIT"
 readme = "README.md"
 packages = [{include = "gis_utils"}]

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+import pandas as pd
+
+
+def test_read_parquet_test_file() -> None:
+    filename = Path(__file__).parent / "testdata" / "example.parquet"
+    df = pd.read_parquet(filename)
+    assert df.shape[0] == 3  # Three rows


### PR DESCRIPTION
- Har lagt til støtte for Git LFS for å kunne lagre større .parquet-filer i katalogen `tests/testdata/`, uten at det øker størrelsen på git repoet. Følg beskrivelsen i README.md for å sette opp Git LFS. Etter oppsett, brukes vanlige git kommandoer, og alle .parquet-filer i denne katalogen vil bli automatisk lagret med Git LFS.
- Se fila `tests/test_parquet.py` for eksempel på innlesing av parquet-fil fra testkatalogen.
- I etterkant av at denne pull requesten er merget til main, så er det fint om du legger inn de andre .parquet-filene du bruker ved testing inn i  `tests/testdata/`-katalogen, pusher og pull request.