### PR TITLE
Don't run SonarCloud analysis on dependabot updates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,12 @@ jobs:
           poetry run pytest --verbose --durations=5 \
             --cov --cov-report=term --cov-report=xml --junitxml=pytest-report.xml
 
+      - name: Debug
+        run: echo "${{ github.actor }}"
+
       - name: SonarCloud Scan
+        # No need to run SonarCloud analysis if dependabot update
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: SonarSource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any


### PR DESCRIPTION
- Pull requests from dependabot does not have access to GitHub Action secrets, so the normal workflow fails. Either add the SONAR_TOKEN to Dependabot secrets, or skip the SonarCloud analysis on dependabot pull requests. The skip solution is selected, since the source code does not change on dependabot pull requests.